### PR TITLE
scatterplot: changed linewidth to edgecolor

### DIFF
--- a/logscatterplot.py
+++ b/logscatterplot.py
@@ -10,8 +10,8 @@ years_ago_male = [2015 - y for y in wikibios.columns_male['birth_year']]
 firstedits_female = wikibios.columns_female['firstedit']
 years_ago_female = [2015 - y for y in wikibios.columns_female['birth_year']]
 
-axes.scatter(firstedits_male, years_ago_male, alpha=0.1, c='green', linewidths=(0,), label='Male')
-axes.scatter(firstedits_female, years_ago_female, alpha=0.1, c='orange', linewidths=(0,), label='Female')
+axes.scatter(firstedits_male, years_ago_male, alpha=0.1, c='green', edgecolors='None', label='Male')
+axes.scatter(firstedits_female, years_ago_female, alpha=0.1, c='orange', edgecolors='None', label='Female')
 axes.set_xlabel('Article Date')
 axes.set_ylabel('Years Ago')
 axes.set_yscale('log')

--- a/scatterplot.py
+++ b/scatterplot.py
@@ -8,12 +8,14 @@ axes = figure.gca()
 
 firstedits_male = wikibios.columns_male['firstedit']
 birth_years_male = wikibios.columns_male['birth_year']
-axes.scatter(firstedits_male, birth_years_male, alpha=0.1, c='green', linewidths=(0,), label='Male')
+axes.scatter(firstedits_male, birth_years_male, alpha=0.1, c='green', edgecolors='None', label='Male')
 
 firstedits_female = wikibios.columns_female['firstedit']
 birth_years_female = wikibios.columns_female['birth_year']
-axes.scatter(firstedits_female, birth_years_female, alpha=0.1, c='orange', linewidths=(0,), label='Female')
+axes.scatter(firstedits_female, birth_years_female, alpha=0.1, c='orange', edgecolors='None', label='Female')
 axes.set_xlabel('Article Date')
 axes.set_ylabel('Birth Year')
 axes.legend()
+
 figure.savefig('scatter.png')
+


### PR DESCRIPTION
As of matplotlib1.14.1, using linewidths=0 in a scatter plot will result in a blank figure when saved.
If the parameter edgecolors=None is used instead, the plot saves correctly.
